### PR TITLE
Fix #46

### DIFF
--- a/src/main/scala/com/chrisrebert/lmvtfy/live_examples/LiveExample.scala
+++ b/src/main/scala/com/chrisrebert/lmvtfy/live_examples/LiveExample.scala
@@ -23,35 +23,36 @@ class JsFiddleExample private(val codeUrl: Uri) extends LiveExample {
   override def equals(other: Any) = other.isInstanceOf[JsFiddleExample] && other.asInstanceOf[JsFiddleExample].codeUrl == codeUrl
 }
 object JsFiddleExample {
+  private val CanonicalHost = NamedHost("fiddle.jshell.net")
   private object Revision {
     def unapply(intStr: String): Option[String] = Try{ intStr.toInt }.toOption.map{ _ => intStr }
   }
   def apply(uri: Uri): Option[JsFiddleExample] = canonicalize(uri).map{ new JsFiddleExample(_) }
   def unapply(uri: Uri): Option[JsFiddleExample] = {
     uri.authority.host match {
-      case NamedHost("jsfiddle.net") => JsFiddleExample(uri)
+      case NamedHost("jsfiddle.net") | CanonicalHost => JsFiddleExample(uri)
       case _ => None
     }
   }
   private def canonicalize(uri: Uri) = {
     val newPath = uri.path.toString.split('/') match {
-      case Array("", identifier)                       => Some(Path / identifier / "show" / "")
-      case Array("", identifier, "show")               => Some(Path / identifier / "show" / "")
-      case Array("", identifier, "embedded", "result") => Some(Path / identifier / "show" / "")
-      case Array("", identifier, Revision(revision))                       => Some(Path / identifier / revision / "show" / "")
-      case Array("", identifier, Revision(revision), "show")               => Some(Path / identifier / revision / "show" / "")
-      case Array("", identifier, Revision(revision), "embedded", "result") => Some(Path / identifier / revision / "show" / "")
+      case Array("", identifier)                       => Some(Path / identifier / "show" / "light" / "")
+      case Array("", identifier, "show")               => Some(Path / identifier / "show" / "light" / "")
+      case Array("", identifier, "embedded", "result") => Some(Path / identifier / "show" / "light" / "")
+      case Array("", identifier, Revision(revision))                       => Some(Path / identifier / revision / "show" / "light" / "")
+      case Array("", identifier, Revision(revision), "show")               => Some(Path / identifier / revision / "show" / "light" / "")
+      case Array("", identifier, Revision(revision), "embedded", "result") => Some(Path / identifier / revision / "show" / "light" / "")
 
-      case Array("", username, identifier)                       => Some(Path / username / identifier / "show" / "")
-      case Array("", username, identifier, "show")               => Some(Path / username / identifier / "show" / "")
-      case Array("", username, identifier, "embedded", "result") => Some(Path / username / identifier / "show" / "")
+      case Array("", username, identifier)                       => Some(Path / username / identifier / "show" / "light" / "")
+      case Array("", username, identifier, "show")               => Some(Path / username / identifier / "show" / "light" / "")
+      case Array("", username, identifier, "embedded", "result") => Some(Path / username / identifier / "show" / "light" / "")
 
-      case Array("", username, identifier, Revision(revision))                       => Some(Path / username / identifier / revision / "show" / "")
-      case Array("", username, identifier, Revision(revision), "show")               => Some(Path / username / identifier / revision / "show" / "")
-      case Array("", username, identifier, Revision(revision), "embedded", "result") => Some(Path / username / identifier / revision / "show" / "")
+      case Array("", username, identifier, Revision(revision))                       => Some(Path / username / identifier / revision / "show" / "light" / "")
+      case Array("", username, identifier, Revision(revision), "show")               => Some(Path / username / identifier / revision / "show" / "light" / "")
+      case Array("", username, identifier, Revision(revision), "embedded", "result") => Some(Path / username / identifier / revision / "show" / "light" / "")
       case _ => None
     }
-    newPath.map{ uri.withPath(_) }
+    newPath.map{ uri.withPath(_).withHost(CanonicalHost) }
   }
 }
 

--- a/src/test/scala/LiveExampleCanonicalizationSpec.scala
+++ b/src/test/scala/LiveExampleCanonicalizationSpec.scala
@@ -42,7 +42,7 @@ class LiveExampleCanonicalizationSpec extends Specification {
 
     "canonicalize URLs for anonymous users correctly" in {
       // JS Fiddle likes trailing slashes
-      val canonicalVersioned = Some(Uri("http://jsfiddle.net/wYc3u/5/show/"))
+      val canonicalVersioned = Some(Uri("http://fiddle.jshell.net/wYc3u/5/show/light/"))
       fiddle("http://jsfiddle.net/wYc3u/5") mustEqual canonicalVersioned
       fiddle("http://jsfiddle.net/wYc3u/5/") mustEqual canonicalVersioned
       fiddle("http://jsfiddle.net/wYc3u/5/show") mustEqual canonicalVersioned
@@ -50,7 +50,7 @@ class LiveExampleCanonicalizationSpec extends Specification {
       fiddle("http://jsfiddle.net/wYc3u/5/embedded/result") mustEqual canonicalVersioned
       fiddle("http://jsfiddle.net/wYc3u/5/embedded/result/") mustEqual canonicalVersioned
 
-      val canonicalUnversioned = Some(Uri("http://jsfiddle.net/wYc3u/show/"))
+      val canonicalUnversioned = Some(Uri("http://fiddle.jshell.net/wYc3u/show/light/"))
       fiddle("http://jsfiddle.net/wYc3u") mustEqual canonicalUnversioned
       fiddle("http://jsfiddle.net/wYc3u/") mustEqual canonicalUnversioned
       fiddle("http://jsfiddle.net/wYc3u/show") mustEqual canonicalUnversioned
@@ -60,7 +60,7 @@ class LiveExampleCanonicalizationSpec extends Specification {
     }
 
     "canonicalize URLs for logged-in users correctly" in {
-      val canonicalUnversioned = Some(Uri("http://jsfiddle.net/cvrebert/7aKxf/show/"))
+      val canonicalUnversioned = Some(Uri("http://fiddle.jshell.net/cvrebert/7aKxf/show/light/"))
       fiddle("http://jsfiddle.net/cvrebert/7aKxf") mustEqual canonicalUnversioned
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/") mustEqual canonicalUnversioned
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/show") mustEqual canonicalUnversioned
@@ -68,7 +68,7 @@ class LiveExampleCanonicalizationSpec extends Specification {
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/embedded/result") mustEqual canonicalUnversioned
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/embedded/result/") mustEqual canonicalUnversioned
 
-      val canonicalVersioned = Some(Uri("http://jsfiddle.net/cvrebert/7aKxf/1/show/"))
+      val canonicalVersioned = Some(Uri("http://fiddle.jshell.net/cvrebert/7aKxf/1/show/light/"))
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/1") mustEqual canonicalVersioned
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/1/") mustEqual canonicalVersioned
       fiddle("http://jsfiddle.net/cvrebert/7aKxf/1/show") mustEqual canonicalVersioned


### PR DESCRIPTION
Should fix #46. Looks like JS Fiddle started using a separate domain for the fiddle content, probably for understandable security reasons.
