### PR TITLE
github-repo-to-watch -> github-repos-to-watch

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -22,7 +22,7 @@ spray.can {
 lmvtfy {
     default-port = 8080
     debug-html = false
-    github-repo-to-watch = ["cvrebert/lmvtfy-test"]
+    github-repos-to-watch = ["cvrebert/lmvtfy-test"]
     username = throwaway9475947
     password = XXXXXXXX
     web-hook-secret-key = abcdefg


### PR DESCRIPTION
This fixes a `com.typesafe.config.ConfigException$Missing: No configuration setting found for key 'lmvtfy.github-repos-to-watch'` runtime fatal error at startup
